### PR TITLE
Modify content structure of "Deploy your Smart Contracts" and get back custom-css to modify sidebar

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -22,7 +22,21 @@ yarn deploy --network sepolia
 
 The deployer account is the account that will deploy your contracts. Additionally, the deployer account will be used to execute any function calls that are part of your deployment script.
 
-You can generate a random account / private key with `yarn generate` or add the private key of your crypto wallet. `yarn generate` will create a random account and add the DEPLOYER_PRIVATE_KEY to the .env file. You can check the generated account with `yarn account`.
+You can generate a random account / private key or add the private key of your crypto wallet.
+
+To create a random account and add the `DEPLOYER_PRIVATE_KEY` to the `.env` file, run:
+
+```
+yarn generate
+```
+
+If you prefer to manually set your own private key, need to add `DEPLOYER_PRIVATE_KEY=yourWalletPrivateKey` to `packages/hardhat/.env` file.
+
+You can check the configured (generated or manually set) account and balances with:
+
+```
+yarn account
+```
 
 ## 3. Deploy your smart contract(s)
 

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 To deploy your smart contracts to a live network, there are a few things you need to adjust.
 
-1. Select the network
+## 1. Select the network
 
 By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` You could also simply run `yarn deploy --network target_network` to deploy to another network.
 
@@ -18,18 +18,13 @@ Example: To deploy the contract to the Sepolia network, run the command below:
 yarn deploy --network sepolia
 ```
 
-2. Generate a new account or add one to deploy the contract(s) from. Additionally you will need to add your Alchemy API key. Rename `.env.example` to `.env` and fill the required keys.
-
-```
-ALCHEMY_API_KEY="",
-DEPLOYER_PRIVATE_KEY=""
-```
+## 2. Generate a new account or add one to deploy the contract(s) from.
 
 The deployer account is the account that will deploy your contracts. Additionally, the deployer account will be used to execute any function calls that are part of your deployment script.
 
 You can generate a random account / private key with `yarn generate` or add the private key of your crypto wallet. `yarn generate` will create a random account and add the DEPLOYER_PRIVATE_KEY to the .env file. You can check the generated account with `yarn account`.
 
-3. Deploy your smart contract(s)
+## 3. Deploy your smart contract(s)
 
 Run the command below to deploy the smart contract to the target network. Make sure to have some funds in your deployer account to pay for the transaction.
 
@@ -37,10 +32,24 @@ Run the command below to deploy the smart contract to the target network. Make s
 yarn deploy --network network_name
 ```
 
-4. Verify your smart contract
+## 4. Verify your smart contract
 
 You can verify your smart contract on Etherscan by running:
 
 ```
 yarn verify --network network_name
 ```
+
+## Configuration of Third-Party Services for Production-Grade Apps.
+
+By default, Scaffold-ETH 2 provides predefined API keys for popular services such as Alchemy and Etherscan. This allows you to begin developing and testing your applications more easily, avoiding the need to register for these services.
+
+For production-grade applications, it's recommended to obtain your own API keys (to prevent rate limiting issues). You can configure these at:
+
+- `ALCHEMY_API_KEY` variable in `packages/hardhat/.env` and `packages/nextjs/.env.local`. You can create API keys from the [Alchemy dashboard](https://dashboard.alchemy.com/).
+
+- `ETHERSCAN_API_KEY` variable in `packages/hardhat/.env` with your generated API key. You can get your key [here](https://etherscan.io/myapikey).
+
+:::tip Hint
+It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
+:::tip Hint

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,9 +46,9 @@ const config = {
             'https://github.com/scaffold-eth/se2-docs/blob/main/',
         },
         blog: false,
-        //theme: {
-        //  customCss: require.resolve('./src/css/custom.css'),
-        //},
+        theme: {
+          customCss: require.resolve('./src/css/custom.css'),
+        },
       }),
     ],
   ],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,0 +1,11 @@
+/* stylelint-disable docusaurus/copyright-header */
+/**
+ * Any CSS included here will be global. The classic template
+ * bundles Infima by default. Infima is a CSS framework designed to
+ * work well for content-centric websites.
+ */
+
+.theme-doc-sidebar-item-link-level-2.menu__list-item {
+  font-size: 14px;
+  padding-left:1rem;
+}


### PR DESCRIPTION
Did a couple of small tweaks to `deploy-smart-contracts.mdx` to make the content more readable, and got back `custom.css` to the repo and uncommented it on Docusaurus config. 

List of changes:
   - Set headers for each step of Deploy Smart Contracts.
   - Create a new section in Deploy Smart Contracts for Third Party APIs in Production-Level Apps,
   - Initial css config for sidebar level 2 items to make the sidebar more readable. 

We can work from here and set more styles when needed for the rest of the Docs.

Solves #8, #9 