### PR TITLE
set default color mode to user system preferences

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,6 +57,9 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       // Replace with your project's social card
+      colorMode : {
+        respectPrefersColorScheme : true
+      },
       image: 'img/thumbnail.jpg',
       navbar: {
         title: 'Scaffold-ETH 2 | Docs',


### PR DESCRIPTION
### Description : 

Updated the default color mode to the system preferred so that people using dark mode won't get hurt when they first time open se-2 docs 

Reference : https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme