### PR TITLE
Add Foundry references

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -8,9 +8,9 @@ To deploy your smart contracts to a live network, there are a few things you nee
 
 ## 1. Select the network
 
-By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` You could also simply run `yarn deploy --network target_network` to deploy to another network.
+By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` or `packages/foundry/foundry.toml` depending if you are using Hardhat or Foundry. You could also simply run `yarn deploy --network target_network` to deploy to another network.
 
-Check the `hardhat.config.ts` for the networks that are pre-configured. You can also add other network settings to the `hardhat.config.ts` file. Here are the [Alchemy docs](https://docs.alchemy.com/docs/how-to-add-alchemy-rpc-endpoints-to-metamask) for information on specific networks.
+Check the `hardhat.config.ts` / `foundry.toml` for the networks that are pre-configured. You can also add other network settings to the `hardhat.config.ts` / `foundry.toml` file. Here are the [Alchemy docs](https://docs.alchemy.com/docs/how-to-add-alchemy-rpc-endpoints-to-metamask) for information on specific networks.
 
 Example: To deploy the contract to the Sepolia network, run the command below:
 
@@ -48,11 +48,21 @@ yarn deploy --network network_name
 
 ## 4. Verify your smart contract
 
-You can verify your smart contract on Etherscan by running:
+In **Hardhat** you can verify your smart contract on Etherscan by running:
 
 ```
 yarn verify --network network_name
 ```
+
+In **Foundry** there isn't a specific command to verify, in this case you need to **Deploy and Verify** within the same command.
+
+```
+yarn deploy:verify --network sepolia
+```
+
+:::info Note
+Currently this command is kind of unstable for custom configured networks but works great for `sepolia` and `goerli`.
+:::info Note
 
 ## Configuration of Third-Party Services for Production-Grade Apps.
 

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -8,7 +8,7 @@ To deploy your smart contracts to a live network, there are a few things you nee
 
 ## 1. Select the network
 
-By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` or `packages/foundry/foundry.toml` depending if you are using Hardhat or Foundry. You could also simply run `yarn deploy --network target_network` to deploy to another network.
+By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` or `packages/foundry/foundry.toml` depending if you are using Hardhat or Foundry.
 
 Check the `hardhat.config.ts` / `foundry.toml` for the networks that are pre-configured. You can also add other network settings to the `hardhat.config.ts` / `foundry.toml` file. Here are the [Alchemy docs](https://docs.alchemy.com/docs/how-to-add-alchemy-rpc-endpoints-to-metamask) for information on specific networks.
 
@@ -30,7 +30,7 @@ To create a random account and add the `DEPLOYER_PRIVATE_KEY` to the `.env` file
 yarn generate
 ```
 
-If you prefer to manually set your own private key, need to add `DEPLOYER_PRIVATE_KEY=yourWalletPrivateKey` to `packages/hardhat/.env` file.
+If you prefer to manually set your own private key, need to add `DEPLOYER_PRIVATE_KEY=yourWalletPrivateKey` to `packages/hardhat/.env` / `packages/foundry/.env` file.
 
 You can check the configured (generated or manually set) account and balances with:
 
@@ -48,21 +48,11 @@ yarn deploy --network network_name
 
 ## 4. Verify your smart contract
 
-In **Hardhat** you can verify your smart contract on Etherscan by running:
+You can verify your smart contract on Etherscan by running:
 
 ```
 yarn verify --network network_name
 ```
-
-In **Foundry** there isn't a specific command to verify, in this case you need to **Deploy and Verify** within the same command.
-
-```
-yarn deploy:verify --network sepolia
-```
-
-:::info Note
-Currently this command is kind of unstable for custom configured networks but works great for `sepolia` and `goerli`.
-:::info Note
 
 ## Configuration of Third-Party Services for Production-Grade Apps.
 
@@ -74,6 +64,4 @@ For production-grade applications, it's recommended to obtain your own API keys 
 
 - `ETHERSCAN_API_KEY` variable in `packages/hardhat/.env` with your generated API key. You can get your key [here](https://etherscan.io/myapikey).
 
-:::tip Hint
-It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
-:::tip Hint
+:::tip Hint It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing. :::tip Hint

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -6,17 +6,14 @@ sidebar_position: 1
 
 To deploy your smart contracts to a live network, there are a few things you need to adjust.
 
-## 1. Select the network
+## 1. Configure your network
 
-By default, `yarn deploy` will deploy the contract to the local network. You can change the defaultNetwork in `packages/hardhat/hardhat.config.ts.` or `packages/foundry/foundry.toml` depending if you are using Hardhat or Foundry.
+Scaffold-ETH 2 comes with a predefined networks. You can also add your custom network in:
 
-Check the `hardhat.config.ts` / `foundry.toml` for the networks that are pre-configured. You can also add other network settings to the `hardhat.config.ts` / `foundry.toml` file. Here are the [Alchemy docs](https://docs.alchemy.com/docs/how-to-add-alchemy-rpc-endpoints-to-metamask) for information on specific networks.
+- Hardhat => `packages/hardhat/hardhat.config.ts`
+- Foundry => `packages/foundry/foundry.toml`
 
-Example: To deploy the contract to the Sepolia network, run the command below:
-
-```
-yarn deploy --network sepolia
-```
+Here are the [Alchemy docs](https://docs.alchemy.com/docs/how-to-add-alchemy-rpc-endpoints-to-metamask) for information on specific networks.
 
 ## 2. Generate a new account or add one to deploy the contract(s) from.
 
@@ -40,11 +37,18 @@ yarn account
 
 ## 3. Deploy your smart contract(s)
 
+By default `yarn deploy` will deploy contract to the local network. You can change `defaultNetwork` in:
+
+- Hardhat => `hardhat.config.ts`
+- Foundry => `foundry.toml`
+
 Run the command below to deploy the smart contract to the target network. Make sure to have some funds in your deployer account to pay for the transaction.
 
 ```
 yarn deploy --network network_name
 ```
+
+eg: `yarn deploy --nework sepolia`
 
 ## 4. Verify your smart contract
 
@@ -62,6 +66,8 @@ For production-grade applications, it's recommended to obtain your own API keys 
 
 - `ALCHEMY_API_KEY` variable in `packages/hardhat/.env` and `packages/nextjs/.env.local`. You can create API keys from the [Alchemy dashboard](https://dashboard.alchemy.com/).
 
-- `ETHERSCAN_API_KEY` variable in `packages/hardhat/.env` with your generated API key. You can get your key [here](https://etherscan.io/myapikey).
+- `ETHERSCAN_API_KEY` variable in `packages/hardhat/.env` | `packages/foundry/.env` with your generated API key. You can get your key [here](https://etherscan.io/myapikey).
 
-:::tip Hint It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing. :::tip Hint
+:::tip Hint
+It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
+:::tip Hint

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,7 +7,7 @@ slug: /
 
 [Scaffold-eth](https://github.com/scaffold-eth/scaffold-eth-2) is everything you need to get started building decentralized applications on Ethereum! 🚀
 
-⚙️ Built using NextJS, RainbowKit, Hardhat, Wagmi, and Typescript.
+⚙️ Built using NextJS, RainbowKit, Hardhat, Foundry, Wagmi, and Typescript.
 
 ## About Scaffold-ETH 2
 
@@ -22,8 +22,9 @@ Scaffold-eth is an open-source, up-to-date toolkit for building decentralized ap
 Scaffold-eth is not a product itself but more of a combination or stack of other great tools. It allows you to quickly build and iterate over your smart contracts and frontends.
 
 Here are the main components:
-- **Hardhat** for running local networks, deploying and testing smart contracts.
+
+- **Hardhat** or **Foundry** (user's choice) for running local networks, deploying and testing smart contracts.
 - **Wagmi** for React Hooks to start working with Ethereum
 - **NextJS** for building a frontend, using many useful pre-made hooks.
 - **RainbowKit** for adding wallet connection
-- **DaisyUI** for pre-built Tailwind CSS components
+- **DaisyUI** for pre-built Tailwind CSS components- **DaisyUI** for pre-built Tailwind CSS components

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,4 +27,4 @@ Here are the main components:
 - **Wagmi** for React Hooks to start working with Ethereum
 - **NextJS** for building a frontend, using many useful pre-made hooks.
 - **RainbowKit** for adding wallet connection
-- **DaisyUI** for pre-built Tailwind CSS components- **DaisyUI** for pre-built Tailwind CSS components
+- **DaisyUI** for pre-built Tailwind CSS components

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -59,8 +59,5 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
 - Edit your frontend in `packages/nextjs/pages`
 - Edit the app config in `packages/nextjs/scaffold.config.ts`
 - Edit your smart contract test in:
-  - Hardhat => `packages/hardhat/test`
-  - Foundry => `packages/foundry/test`
-- Run smart contract test with:
-  - Hardhat => `yarn hardhat:test`
-  - Foundry => `yarn foundry:test`
+  - Hardhat => `packages/hardhat/test` to run test use `yarn hardhat:test`
+  - Foundry => `packages/foundry/test` to run test use `yarn foundry:test`

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -17,8 +17,8 @@ yarn chain
 
 This command starts a local Ethereum network using Hardhat or Foundry, depending on which one you selected in the CLI. The network runs on your local machine and can be used for testing and development. You can customize the network configuration in:
 
-- `packages/hardhat/hardhat.config.ts` if you have Hardhat as solidity framework.
-- `packages/foundry/foundry.toml` if you have Foundry as solidity framework.
+- Hardhat => `packages/hardhat/hardhat.config.ts`
+- Foundry => `packages/foundry/foundry.toml`
 
 ### 2. **Deploy Your Smart Contract**:
 
@@ -28,12 +28,12 @@ In the second terminal, deploy the test contract:
 yarn deploy
 ```
 
-This command deploys a test smart contract to the local network. The contract can be modified to suit your needs. Is located in:
+This command deploys a test smart contract to the local network. The contract can be modified to suit your needs and can be found in:
 
 - Hardhat => `packages/hardhat/contracts`
 - Foundry => `packages/foundry/contracts`
 
-The `yarn deploy` command uses a deploy script to deploy the contract to the network. You can customize it. Is located in:
+The `yarn deploy` command uses a deploy script to deploy the contract to the network. You can customize the deployment script located in:
 
 - Hardhat => `packages/hardhat/deploy`
 - Foundry => `packages/foundry/script`
@@ -58,4 +58,9 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
   - Foundry => `packages/foundry/script`
 - Edit your frontend in `packages/nextjs/pages`
 - Edit the app config in `packages/nextjs/scaffold.config.ts`
-- Run smart contract test with `yarn hardhat:test`
+- Edit your smart contract test in:
+  - Hardhat => `packages/hardhat/test`
+  - Foundry => `packages/foundry/test`
+- Run smart contract test with:
+  - Hardhat => `yarn hardhat:test`
+  - Foundry => `yarn foundry:test`

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -15,7 +15,10 @@ In the first terminal, run a local network:
 yarn chain
 ```
 
-This command starts a local Ethereum network using Hardhat. The network runs on your local machine and can be used for testing and development. You can customize the network configuration in `hardhat.config.ts`.
+This command starts a local Ethereum network using Hardhat or Foundry, depending on which one you selected in the CLI. The network runs on your local machine and can be used for testing and development. You can customize the network configuration in:
+
+- `packages/hardhat/hardhat.config.ts` if you have Hardhat as solidity framework.
+- `packages/foundry/foundry.toml` if you have Foundry as solidity framework.
 
 ### 2. **Deploy Your Smart Contract**:
 
@@ -25,7 +28,15 @@ In the second terminal, deploy the test contract:
 yarn deploy
 ```
 
-This command deploys a test smart contract to the local network. The contract is located in `packages/hardhat/contracts` and can be modified to suit your needs. The `yarn deploy` command uses the deploy script located in `packages/hardhat/deploy` to deploy the contract to the network. You can also customize the deploy script.
+This command deploys a test smart contract to the local network. The contract can be modified to suit your needs. Is located in:
+
+- Hardhat => `packages/hardhat/contracts`
+- Foundry => `packages/foundry/contracts`
+
+The `yarn deploy` command uses a deploy script to deploy the contract to the network. You can customize it. Is located in:
+
+- Hardhat => `packages/hardhat/deploy`
+- Foundry => `packages/foundry/script`
 
 ### 3. **Launch your NextJS Application**:
 
@@ -39,8 +50,12 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
 
 ## What's Next:
 
-- Edit your smart contract `YourContract.sol` in `packages/hardhat/contracts`
-- Edit your deployment scripts in `packages/hardhat/deploy`
+- Edit your smart contract:
+  - Hardhat => `YourContract.sol` in `packages/hardhat/contracts`
+  - Foundry => `YourContract.sol` in `packages/foundry/contracts`
+- Edit your deployment scripts:
+  - Hardhat => `packages/hardhat/deploy`
+  - Foundry => `packages/foundry/script`
 - Edit your frontend in `packages/nextjs/pages`
 - Edit the app config in `packages/nextjs/scaffold.config.ts`
 - Run smart contract test with `yarn hardhat:test`

--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -51,3 +51,8 @@ Once the setup is complete, navigate to the project directory:
 ```
 cd project-name
 ```
+
+:::info Hint
+If you choose Foundry as solidity framework in the CLI, you'll also need Foundryup installed in your machine.  
+Checkout: [getfoundry.sh](https://getfoundry.sh/)
+:::info Hint


### PR DESCRIPTION
Adding Foundry references and adapting explanations depending on the solidity framework selected by the user on CLI.

Since we already have `npx create-eth@latest` as [Beta] installation mode, it makes sense to have Foundry added as well.

This PR will let us update [SE-2 CLI branch](https://github.com/scaffold-eth/scaffold-eth-2/tree/cli) README to a reduced version with link to the full Docs.

**Note:** I was not sure about adding this hint to the Installation page, only saw 1 people in TG dev chat asking about `foundryup` so far. **What do you think?**

![image](https://github.com/scaffold-eth/se2-docs/assets/55535804/0d2e0b08-7d9c-4ccb-b33e-ca4e4d525cfb)
