### PR TITLE
add passing args  imperatively to `writeAsync` example

### DIFF
--- a/docs/hooks/useScaffoldContractWrite.md
+++ b/docs/hooks/useScaffoldContractWrite.md
@@ -11,8 +11,8 @@ const { writeAsync, isLoading, isMining } = useScaffoldContractWrite({
   contractName: "YourContract",
   functionName: "setGreeting",
   args: ["The value to set"],
-  // For payable functions, expressed in ETH
-  value: "0.01",
+  // For payable functions
+  value: parseEther("0.1"),
   // The number of block confirmations to wait for before considering transaction to be confirmed (default : 1).
   blockConfirmations: 1,
   // The callback function to execute when the transaction is confirmed.
@@ -24,10 +24,18 @@ const { writeAsync, isLoading, isMining } = useScaffoldContractWrite({
 
 To send the transaction, you can call the `writeAsync` function returned by the hook. Here's an example usage:
 
-```ts
+```tsx
 <button className="btn btn-primary" onClick={() => writeAsync()}>
   Send TX
 </button>
 ```
 
 This example sends a transaction to the `YourContract` smart contract to call the `setGreeting` function with the arguments passed in `args`. The `writeAsync` function sends the transaction to the smart contract, and the `isLoading` and `isMining` properties indicate whether the transaction is currently being processed by the network.
+
+It is also possible to pass arguments imperatively to the `writeAsync` function:
+
+```tsx
+<button className="btn btn-primary" onClick={() => writeAsync({ args: ["Dynamic value"], value: parseEther("0.2") })}>
+  Send TX
+</button>
+```


### PR DESCRIPTION
Fixes #22 