### PR TITLE
Fix typo on yarn deploy --network code example

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -48,7 +48,7 @@ Run the command below to deploy the smart contract to the target network. Make s
 yarn deploy --network network_name
 ```
 
-eg: `yarn deploy --nework sepolia`
+eg: `yarn deploy --network sepolia`
 
 ## 4. Verify your smart contract
 


### PR DESCRIPTION
Small typo on "--nework" instead of "--network" but makes the command fail for those that copy it 😅