### PR TITLE
Add viem to SE-2 tech stack

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,6 +25,7 @@ Here are the main components:
 
 - [**Hardhat**](https://hardhat.org/docs) or [**Foundry**](https://book.getfoundry.sh/) (user's choice) for running local networks, deploying and testing smart contracts.
 - [**Wagmi**](https://wagmi.sh/react/getting-started) for React Hooks to start working with Ethereum.
+- [**Viem**](https://viem.sh/docs/getting-started) as low-level interface that provides primitives to interact with Ethereum. The alternative to ethers.js and web3.js.
 - [**NextJS**](https://nextjs.org/docs) for building a frontend, using many useful pre-made hooks.
 - [**RainbowKit**](https://www.rainbowkit.com/docs/) for adding wallet connection.
 - [**DaisyUI**](https://daisyui.com/docs/) for pre-built [Tailwind CSS](https://tailwindui.com/components) components.


### PR DESCRIPTION
In response to a Telegram conversation about using Ethers in SE-2 Nextjs part, it would be beneficial to add a reference to Viem in our tech stack to clarify any doubts.

Closes #51 

Would you add a small reference in this part of SE-2 Readme also?

![image](https://github.com/scaffold-eth/se2-docs/assets/55535804/74cb74c9-c338-4c92-a25b-9d4df554bdc2)
