### PR TITLE
Adapt docs to App Router update and add Foundry use case to verify section

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -60,12 +60,12 @@ yarn verify --network network_name
 
 eg: `yarn verify --network sepolia`
 
-This command **works in both Hardhat and Foundry**, verifying all the deployed contracts. The method of verification varies within the solidity framework:
+This command **works in both Hardhat and Foundry**, verifying all the deployed contracts. However, the verification method differs depending on the Solidity framework you're using:
 
 - Hardhat => uses [etherscan-verify from hardhat-deploy](https://www.npmjs.com/package/hardhat-deploy#4-hardhat-etherscan-verify).
 - Foundry => uses `VerifyAll.s.sol` script located in `packages/foundry/script`.
 
-**In Hardhat**, you can alternatively use [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) to verify your contracts, passing network name, contract address and constructor arguments (if any): `yarn hardhat-verify --network network_name contract_address "Constructor arg 1"`
+Additionally, **in Hardhat**, there's an alternative method for contract verification. You can use [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) to verify your contracts, passing in the network name, contract address and constructor arguments (if any): `yarn hardhat-verify --network network_name contract_address "Constructor arg 1"`
 
 If the chain you're using is not supported by any of the verifying methods, you can add new supported chains to your chosen method, either [etherscan-verify](https://www.npmjs.com/package/hardhat-deploy#options-2) or [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#adding-support-for-other-networks).
 

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -60,9 +60,12 @@ yarn verify --network network_name
 
 eg: `yarn verify --network sepolia`
 
-This uses [etherscan-verify from hardhat-deploy](https://www.npmjs.com/package/hardhat-deploy#4-hardhat-etherscan-verify) to verify all the deployed contracts.
+This command **works in both Hardhat and Foundry**, verifying all the deployed contracts. The method of verification varies within the solidity framework:
 
-You can alternatively use [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) to verify your contracts, passing network name, contract address and constructor arguments (if any): `yarn hardhat-verify --network network_name contract_address "Constructor arg 1"`
+- Hardhat => uses [etherscan-verify from hardhat-deploy](https://www.npmjs.com/package/hardhat-deploy#4-hardhat-etherscan-verify).
+- Foundry => uses `VerifyAll.s.sol` script located in `packages/foundry/script`.
+
+**In Hardhat**, you can alternatively use [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) to verify your contracts, passing network name, contract address and constructor arguments (if any): `yarn hardhat-verify --network network_name contract_address "Constructor arg 1"`
 
 If the chain you're using is not supported by any of the verifying methods, you can add new supported chains to your chosen method, either [etherscan-verify](https://www.npmjs.com/package/hardhat-deploy#options-2) or [hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#adding-support-for-other-networks).
 

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -56,7 +56,7 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
 - Edit your deployment scripts:
   - Hardhat => `packages/hardhat/deploy`
   - Foundry => `packages/foundry/script`
-- Edit your frontend in `packages/nextjs/app/page.tsx` (homepage), and the rest of [pages / layouts](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts) for the different [routes](https://nextjs.org/docs/app/building-your-application/routing/defining-routes) of your application.
+- Edit your frontend homepage at `packages/nextjs/app/page.tsx`. For guidance on [routing](https://nextjs.org/docs/app/building-your-application/routing/defining-routes) and configuring [pages/layouts](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts) checkout the Next.js documentation.
 - Edit the app config in `packages/nextjs/scaffold.config.ts`
 - Edit your smart contract test in:
   - Hardhat => `packages/hardhat/test` to run test use `yarn hardhat:test`

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -56,7 +56,7 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
 - Edit your deployment scripts:
   - Hardhat => `packages/hardhat/deploy`
   - Foundry => `packages/foundry/script`
-- Edit your frontend in `packages/nextjs/pages`
+- Edit your frontend in `packages/nextjs/app/page.tsx` (homepage), and the rest of [pages / layouts](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts) for the different [routes](https://nextjs.org/docs/app/building-your-application/routing/defining-routes) of your application.
 - Edit the app config in `packages/nextjs/scaffold.config.ts`
 - Edit your smart contract test in:
   - Hardhat => `packages/hardhat/test` to run test use `yarn hardhat:test`

--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -9,7 +9,7 @@ description: Requirements and installation methods to get started with Scaffold 
 
 Before you begin, you need to install the following tools:
 
-- [Node (v18 LTS)](https://nodejs.org/en/download/)
+- [Node (>= v18.17)](https://nodejs.org/en/download/)
 - Yarn ([v1](https://classic.yarnpkg.com/en/docs/install/) or [v2+](https://yarnpkg.com/getting-started/install))
 - [Git](https://git-scm.com/downloads)
 
@@ -53,6 +53,6 @@ cd project-name
 ```
 
 :::info Hint
-If you choose Foundry as solidity framework in the CLI, you'll also need Foundryup installed on your machine.  
+If you choose Foundry as solidity framework in the CLI, you'll also need Foundryup installed on your machine.
 Checkout: [getfoundry.sh](https://getfoundry.sh/)
 :::info Hint


### PR DESCRIPTION
Adding these two changes in the same PR, they are not related but are small enough to not create 2 PRs I think:

- Closes #53 
- Closes #55. Here I could have added a reference to `yarn deploy:verify` but maybe just adds complexity to the section. What do you think?


Regarding [Documenting folder structure](https://github.com/scaffold-eth/scaffold-eth-2/pull/535#issuecomment-1879794609) I think we could document the components structure in `/components` category description. Another possibility would be adding a new bullet point in "What's Next"  from `/quick-start/environment`, with something like "Add new components (if you need any) in...".

Let me know what do you think, thanks! 🙌

