### PR TITLE
Fix wagmi 1.x. doc links

### DIFF
--- a/docs/hooks/useScaffoldContract.md
+++ b/docs/hooks/useScaffoldContract.md
@@ -32,10 +32,10 @@ This example uses the `useScaffoldContract` hook to obtain a contract instance f
 
 ## Configuration
 
-| Parameter                   | Type                                                           | Description                                                                   |
-| :-------------------------- | :------------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| **contractName**            | `string`                                                       | Name of the contract.                                                         |
-| **walletClient** (optional) | [`WalletClient`](https://wagmi.sh/react/hooks/useWalletClient) | Wallet client must be passed in order to call `write` methods of the contract |
+| Parameter                   | Type                                                               | Description                                                                   |
+| :-------------------------- | :----------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| **contractName**            | `string`                                                           | Name of the contract.                                                         |
+| **walletClient** (optional) | [`WalletClient`](https://1.x.wagmi.sh/react/hooks/useWalletClient) | Wallet client must be passed in order to call `write` methods of the contract |
 
 ## Return Value
 

--- a/docs/hooks/useScaffoldContractRead.md
+++ b/docs/hooks/useScaffoldContractRead.md
@@ -24,10 +24,10 @@ This example retrieves the data returned by the `userGreetingCounter` function o
 | **functionName**    | `string` | Name of the function to call.                                |
 | **args** (optional) | `any[]`  | Array of arguments to pass to the function (if accepts any). |
 
-You can also pass other arguments accepted by [useContractRead wagmi hook](https://wagmi.sh/react/hooks/useContractRead#configuration).
+You can also pass other arguments accepted by [useContractRead wagmi hook](https://1.x.wagmi.sh/react/hooks/useContractRead#configuration).
 
 ## Return Values
 
 - The retrieved data is stored in the `data` property of the returned object.
 - You can refetch the data by calling the `refetch` function.
-- The extended object includes properties inherited from wagmi useContractRead. You can check the [useContractRead return values](https://wagmi.sh/react/hooks/useContractRead#return-value) documentation to check the types.
+- The extended object includes properties inherited from wagmi useContractRead. You can check the [useContractRead return values](https://1.x.wagmi.sh/react/hooks/useContractRead#return-value) documentation to check the types.

--- a/docs/hooks/useScaffoldContractWrite.md
+++ b/docs/hooks/useScaffoldContractWrite.md
@@ -48,10 +48,10 @@ It is also possible to pass arguments imperatively to the `writeAsync` function:
 | **onBlockConfirmation** (optional) | `function` | Callback function to execute when the transaction is confirmed.                                         |
 | **blockConfirmations** (optional)  | `number`   | Number of block confirmations to wait for before considering transaction to be confirmed (default : 1). |
 
-You can also pass other arguments accepted by [useContractWrite wagmi hook](https://wagmi.sh/react/hooks/useContractWrite#configuration).
+You can also pass other arguments accepted by [useContractWrite wagmi hook](https://1.x.wagmi.sh/react/hooks/useContractWrite#configuration).
 
 ## Return Values
 
 - `writeAsync` function sends the transaction to the smart contract.
 - `isMining` property indicates whether the transaction is currently being mined.
-- The extended object includes properties inherited from wagmi useContractWrite. You can check the [useContractWrite return values](https://wagmi.sh/react/hooks/useContractWrite#return-value) documentation to check the types.
+- The extended object includes properties inherited from wagmi useContractWrite. You can check the [useContractWrite return values](https://1.x.wagmi.sh/react/hooks/useContractWrite#return-value) documentation to check the types.

--- a/docs/hooks/useScaffoldEventSubscriber.md
+++ b/docs/hooks/useScaffoldEventSubscriber.md
@@ -24,7 +24,7 @@ useScaffoldEventSubscriber({
 
 This example subscribes to the `GreetingChange` event emitted by the `YourContract` smart contract and logs the parameters from the event to the console when it's emitted.
 
-This hook is a wrapper around wagmi's [useContractEvent](https://wagmi.sh/react/hooks/useContractEvent).
+This hook is a wrapper around wagmi's [useContractEvent](https://1.x.wagmi.sh/react/hooks/useContractEvent).
 
 ## Configuration
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -24,7 +24,7 @@ Scaffold-ETH is not a product itself but more of a combination or stack of other
 Here are the main components:
 
 - [**Hardhat**](https://hardhat.org/docs) or [**Foundry**](https://book.getfoundry.sh/) (user's choice) for running local networks, deploying and testing smart contracts.
-- [**Wagmi**](https://wagmi.sh/react/getting-started) for React Hooks to start working with Ethereum.
+- [**Wagmi**](https://1.x.wagmi.sh/react/getting-started) for React Hooks to start working with Ethereum.
 - [**Viem**](https://viem.sh/docs/getting-started) as low-level interface that provides primitives to interact with Ethereum. The alternative to ethers.js and web3.js.
 - [**NextJS**](https://nextjs.org/docs) for building a frontend, using many useful pre-made hooks.
 - [**RainbowKit**](https://www.rainbowkit.com/docs/) for adding wallet connection.

--- a/docs/recipes/GetCurrentBalanceFromAccount.md
+++ b/docs/recipes/GetCurrentBalanceFromAccount.md
@@ -54,7 +54,7 @@ export const ConnectedAddressBalance = () => {
 
 ### Step 2: Retrieve the Connected Account
 
-Fetch the Ethereum address of the currently connected account using the [useAccount wagmi hook](https://wagmi.sh/react/hooks/useAccount) and easily display them using Scaffold ETH-2 [Address](/components/Address) and [Balance](/components/Balance) components.
+Fetch the Ethereum address of the currently connected account using the [useAccount wagmi hook](https://1.x.wagmi.sh/react/hooks/useAccount) and easily display them using Scaffold ETH-2 [Address](/components/Address) and [Balance](/components/Balance) components.
 
 ```tsx title="components/ConnectedAddressBalance.tsx"
 // highlight-start

--- a/docs/recipes/ReadUintFromContract.md
+++ b/docs/recipes/ReadUintFromContract.md
@@ -110,7 +110,7 @@ In the contract, `totalCounter` returns an `uint` value, which is represented as
 
 ### Step 3: Retrieve connected address greetings count
 
-We can get the connected address using the [useAccount](https://wagmi.sh/react/hooks/useAccount) hook and pass it to `args` key in the `useScaffoldContractRead` hook configuration. This will be used as an argument to read the contract function.
+We can get the connected address using the [useAccount](https://1.x.wagmi.sh/react/hooks/useAccount) hook and pass it to `args` key in the `useScaffoldContractRead` hook configuration. This will be used as an argument to read the contract function.
 
 ```tsx title="components/GreetingsCount.tsx"
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";


### PR DESCRIPTION
Links to Wagmi are broken (I guess since they migrated to v2)

This PR fixes the links (until we merge https://github.com/scaffold-eth/scaffold-eth-2/pull/700)