### PR TITLE
fix: remove non-existent Balance className prop, fix IntegerInput type

### DIFF
--- a/docs/pages/components/Balance.md
+++ b/docs/pages/components/Balance.md
@@ -23,10 +23,9 @@ import { Balance } from "@scaffold-ui/components";
 
 ## Props
 
-| Prop                     | Type     | Default Value | Description                                                                                                               |
-| ------------------------ | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **address**              | `string` | `undefined`   | Address in `0x___` format, it will resolve its ENS if it has one associated.                                              |
-| **className** (optional) | `string` | `""`          | Prop to pass additional CSS styling to the component. You can use Tailwind / daisyUI classes like `text-3xl` for styling. |
+| Prop        | Type     | Default Value | Description                                                  |
+| ----------- | -------- | ------------- | ------------------------------------------------------------ |
+| **address** | `string` | `undefined`   | Address in `0x___` format to display the balance for.        |
 
 :::tip[Scaffold-UI]
 For more details on customization and theming, check the [Scaffold-UI Balance docs](https://scaffold-ui-docs.vercel.app/components/Balance).

--- a/docs/pages/components/IntegerInput.md
+++ b/docs/pages/components/IntegerInput.md
@@ -19,7 +19,7 @@ import { IntegerInput } from "@scaffold-ui/debug-contracts";
 ## Usage
 
 ```tsx
-const [txValue, setTxValue] = useState<string | bigint>("");
+const [txValue, setTxValue] = useState("");
 ```
 
 ```tsx


### PR DESCRIPTION
## Summary
- **Balance**: Removed `className` prop from docs — it doesn't exist in scaffold-ui's `BalanceProps`. Was causing confusion.
- **IntegerInput**: Fixed usage example from `useState<string | bigint>("")` to `useState("")` since the component only accepts `string`.

## Test plan
- [ ] Verify Balance and IntegerInput doc pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)