### PR TITLE
feat: agent discoverability — robots.txt, sitemap, Link headers, Content Signals, agent-skills index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ docs/pages/build-with-ai/*.md
 
 # Generated at build time by scripts/gen-sitemap.ts (see vocs.config.ts)
 docs/public/sitemap.xml
+
+# Generated at build time by scripts/fetch-skills.ts (raw skill mirrors
+# consumed by the agent-skills discovery index)
+docs/public/skills/
+
+# Generated at build time by scripts/gen-agent-skills-index.ts
+docs/public/.well-known/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ docs/dist
 # Generated at build time by fetching from GitHub API (see vocs.config.ts)
 docs/pages/build-with-ai/*.md
 !docs/pages/build-with-ai/agents-md.md
+
+# Generated at build time by scripts/gen-sitemap.ts (see vocs.config.ts)
+docs/public/sitemap.xml

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -3,6 +3,7 @@
 
 User-agent: *
 Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 # AI training and search crawlers — explicitly allowed so agents can
 # index SE-2 patterns, hooks, components, recipes, and skills.

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,66 @@
+# Scaffold-ETH 2 documentation is open-source and intended to be
+# discoverable by search engines and AI agents. Crawl freely.
+
+User-agent: *
+Allow: /
+
+# AI training and search crawlers — explicitly allowed so agents can
+# index SE-2 patterns, hooks, components, recipes, and skills.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: MistralAI-User
+Allow: /
+
+Sitemap: https://docs.scaffoldeth.io/sitemap.xml

--- a/scripts/fetch-skills.ts
+++ b/scripts/fetch-skills.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const SKILLS_DIR = "docs/pages/build-with-ai";
+const RAW_SKILLS_DIR = "docs/public/skills";
 const RAW_BASE =
   "https://raw.githubusercontent.com/scaffold-eth/scaffold-eth-2/main/.agents/skills";
 const GITHUB_API =
@@ -42,6 +43,11 @@ async function fetchAndWriteSkill(name: string): Promise<Skill | null> {
     path.join(SKILLS_DIR, `${name}.md`),
     `---\ntitle: "${name}"\ndescription: "${shortDesc}"\n---\n\n\`\`\`yaml\n---\n${originalFrontmatter}\n---\n\`\`\`\n\n${body}`,
   );
+
+  // Raw, untouched SKILL.md for agent discovery index (/.well-known/agent-skills)
+  const rawDir = path.join(RAW_SKILLS_DIR, name);
+  fs.mkdirSync(rawDir, { recursive: true });
+  fs.writeFileSync(path.join(rawDir, "SKILL.md"), raw);
 
   return { name, title: name, shortDesc };
 }
@@ -101,6 +107,14 @@ function readExistingSkills(): Skill[] | null {
     );
 
   if (files.length === 0) return null;
+
+  // Require the raw SKILL.md mirrors to exist too — they feed the agent-skills
+  // discovery index. If any are missing, bust the cache and re-fetch.
+  const allRawPresent = files.every((f) => {
+    const name = f.replace(".md", "");
+    return fs.existsSync(path.join(RAW_SKILLS_DIR, name, "SKILL.md"));
+  });
+  if (!allRawPresent) return null;
 
   return files.map((f) => {
     const name = f.replace(".md", "");

--- a/scripts/gen-agent-skills-index.ts
+++ b/scripts/gen-agent-skills-index.ts
@@ -1,0 +1,101 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+const ROOT_SKILL = "docs/public/SKILL.md";
+const SKILLS_DIR = "docs/public/skills";
+const OUTPUT = "docs/public/.well-known/agent-skills/index.json";
+const PRODUCTION_URL = "https://docs.scaffoldeth.io";
+
+type SkillType = "skill-md" | "archive";
+
+type SkillEntry = {
+  name: string;
+  type: SkillType;
+  description: string;
+  url: string;
+  digest: string;
+};
+
+function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_URL;
+}
+
+function sha256Digest(filePath: string): string {
+  const buf = fs.readFileSync(filePath);
+  return `sha256:${crypto.createHash("sha256").update(buf).digest("hex")}`;
+}
+
+function parseFrontmatter(source: string): Record<string, string> {
+  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const body = match[1];
+  const out: Record<string, string> = {};
+  for (const line of body.split(/\r?\n/)) {
+    const kv = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[kv[1]] = value;
+  }
+  return out;
+}
+
+function buildEntry(filePath: string, routePath: string, fallbackName: string, baseUrl: string): SkillEntry | null {
+  if (!fs.existsSync(filePath)) return null;
+  const source = fs.readFileSync(filePath, "utf8");
+  const fm = parseFrontmatter(source);
+  const name = (fm.name || fallbackName).toLowerCase();
+  const description = fm.description || `${name} skill for Scaffold-ETH 2`;
+
+  return {
+    name,
+    type: "skill-md",
+    description,
+    url: `${baseUrl}${routePath}`,
+    digest: sha256Digest(filePath),
+  };
+}
+
+let generated = false;
+
+export function generateAgentSkillsIndex(): void {
+  if (generated) return;
+  generated = true;
+
+  const baseUrl = resolveBaseUrl();
+  const entries: SkillEntry[] = [];
+
+  const root = buildEntry(ROOT_SKILL, "/SKILL.md", "ethereum-app-builder", baseUrl);
+  if (root) entries.push(root);
+
+  if (fs.existsSync(SKILLS_DIR)) {
+    for (const dir of fs.readdirSync(SKILLS_DIR, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue;
+      const skillFile = path.join(SKILLS_DIR, dir.name, "SKILL.md");
+      const entry = buildEntry(skillFile, `/skills/${dir.name}/SKILL.md`, dir.name, baseUrl);
+      if (entry) entries.push(entry);
+    }
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const index = {
+    $schema: SCHEMA_URL,
+    skills: entries,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(index, null, 2) + "\n");
+
+  console.log(`✅ Generated agent-skills index with ${entries.length} skills (base: ${baseUrl})`);
+}

--- a/scripts/gen-sitemap.ts
+++ b/scripts/gen-sitemap.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const PAGES_DIR = "docs/pages";
+const OUTPUT = "docs/public/sitemap.xml";
+
+const PRODUCTION_URL = "https://docs.scaffoldeth.io";
+
+function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_URL;
+}
+
+function collectRoutes(dir: string, basePath = ""): string[] {
+  const routes: string[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const { name } = entry;
+    if (name.startsWith("_") || name.startsWith(".")) continue;
+
+    const full = path.join(dir, name);
+
+    if (entry.isDirectory()) {
+      routes.push(...collectRoutes(full, `${basePath}/${name}`));
+      continue;
+    }
+
+    if (!/\.(md|mdx)$/.test(name)) continue;
+
+    const bare = name.replace(/\.(md|mdx)$/, "");
+    const route = bare === "index" ? basePath || "/" : `${basePath}/${bare}`;
+    routes.push(route);
+  }
+
+  return routes;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toXml(routes: string[], baseUrl: string): string {
+  const lastmod = new Date().toISOString().slice(0, 10);
+
+  const urls = [...routes]
+    .sort()
+    .map((route) => {
+      const loc = escapeXml(route === "/" ? baseUrl : `${baseUrl}${route}`);
+      const priority = route === "/" ? "1.0" : "0.8";
+      return [
+        "  <url>",
+        `    <loc>${loc}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>weekly</changefreq>`,
+        `    <priority>${priority}</priority>`,
+        "  </url>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+let generated = false;
+
+export function generateSitemap(): void {
+  if (generated) return;
+  generated = true;
+
+  if (!fs.existsSync(PAGES_DIR)) {
+    console.warn(`⚠️  ${PAGES_DIR} not found — skipping sitemap generation`);
+    return;
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const routes = collectRoutes(PAGES_DIR);
+  const xml = toXml(routes, baseUrl);
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, xml);
+
+  console.log(`✅ Generated sitemap.xml with ${routes.length} URLs (base: ${baseUrl})`);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly documentation index\", </llms-full.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly full documentation\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </SKILL.md>; rel=\"alternate\"; type=\"text/markdown\"; title=\"Scaffold-ETH 2 agent skill\""
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/quick-start",

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "vocs";
 import { fetchSkills } from "./scripts/fetch-skills";
+import { generateAgentSkillsIndex } from "./scripts/gen-agent-skills-index";
 import { generateSitemap } from "./scripts/gen-sitemap";
 
 const skills = await fetchSkills();
 generateSitemap();
+generateAgentSkillsIndex();
 
 const skillSidebarItems = skills.map((s) => ({
   text: s.title,

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vocs";
 import { fetchSkills } from "./scripts/fetch-skills";
+import { generateSitemap } from "./scripts/gen-sitemap";
 
 const skills = await fetchSkills();
+generateSitemap();
 
 const skillSidebarItems = skills.map((s) => ({
   text: s.title,


### PR DESCRIPTION
## Summary

Takes `docs.scaffoldeth.io` on [isitagentready.com](https://isitagentready.com/docs.scaffoldeth.io) from **0/12 → 6/12** (Level 0 → Level 2). No content changes — only additions under `docs/public/` and two build-time scripts.

- `robots.txt` — AI bot `Allow` rules + Content Signals (`ai-train=yes, search=yes, ai-input=yes`) + `Sitemap:` pointer
- `sitemap.xml` — auto-generated from `docs/pages/**`, runs on every build
- `Link:` header on every response pointing to `llms.txt`, `llms-full.txt`, `sitemap.xml`, `SKILL.md`
- `/.well-known/agent-skills/index.json` — RFC v0.2.0 discovery index, 9 skills, sha256 digests over raw SKILL.md bytes 

Before: https://isitagentready.com/docs.scaffoldeth.io

After: https://isitagentready.com/scaffold-eth-2-docs-git-feat-agent-ready-d-afd99c-buidlguidldao.vercel.app

Also another thing they ask you to share the markdown version of the pages: 

<img width="908" height="630" alt="Screenshot 2026-04-21 at 10 34 42 AM" src="https://github.com/user-attachments/assets/988ca8c6-a52d-442c-b1e2-ac4a56b87fee" />

The reason I didn't add it was, agents already have full access to the content. `/llms.txt` (index) and `/llms-full.txt` (every page concatenated as plain markdown) are already served at the root and are advertised on every response via the `Link: </llms.txt>; rel="alternate"` header we just added. 

<details>

<summary>
    More details: 
</summary>

## Changes

### robots.txt + Content Signals
- **`docs/public/robots.txt`** — permissive policy with explicit `Allow` rules for major AI crawlers (GPTBot, ClaudeBot, Claude-SearchBot, Claude-User, PerplexityBot, Google-Extended, Applebot-Extended, CCBot, Bytespider, Meta-ExternalAgent, MistralAI-User, cohere-ai, etc.), a `Sitemap:` directive, and `Content-Signal: ai-train=yes, search=yes, ai-input=yes` per [draft-romm-aipref-contentsignals](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/).

### Sitemap
- **`scripts/gen-sitemap.ts`** — walks `docs/pages/**/*.{md,mdx}`, mirrors Vocs' file-based routing (`index.md` → parent segment, filename casing preserved so `/components/Address` stays capitalised), emits `docs/public/sitemap.xml`. Wired into `vocs.config.ts` right after `fetchSkills()` so auto-fetched skill pages are included.

### Link headers
- **`vercel.json`** — adds `Link` header (RFC 8288) on every response advertising `llms.txt`, `llms-full.txt`, `sitemap.xml`, and `SKILL.md` so agent crawlers discover machine-readable resources without parsing HTML.

### Agent Skills Discovery (RFC v0.2.0)
- **`scripts/fetch-skills.ts`** — now also mirrors each SKILL.md verbatim into `docs/public/skills/<name>/SKILL.md` (alongside the existing Vocs page write). Cache check extended so missing raw files bust the cache.
- **`scripts/gen-agent-skills-index.ts`** — new; globs raw skills + root orchestrator, parses frontmatter (`name`, `description`), computes `sha256:{hex}` over raw bytes, emits `docs/public/.well-known/agent-skills/index.json` against `https://schemas.agentskills.io/discovery/0.2.0/schema.json`. Currently publishes 9 entries (1 orchestrator + 8 upstream skills); adding a new skill to `scaffold-eth-2/.agents/skills/` requires no changes here.

### Housekeeping
- **`.gitignore`** — excludes `docs/public/sitemap.xml`, `docs/public/skills/`, and `docs/public/.well-known/` since all regenerate on every build.

## Why `ai-train=yes, ai-input=yes`?

SE-2 is MIT-licensed OSS explicitly designed to teach dapp patterns. Agents training on it → more builders ship. Agents fetching it as RAG context is the entire reason `llms.txt` and `SKILL.md` exist. Opting in to both aligns with the project's mission.

## Why not upstream sitemap/skills to Vocs?

[Vocs#204](https://github.com/wevm/vocs/issues/204) (sitemap) was closed without implementation. The maintainer's stance on [#367](https://github.com/wevm/vocs/issues/367) (MCP) is that `llms.txt` supersedes these formats. SE-2 owns these locally.

## Test plan

- [ ] `pnpm build` locally — confirm `docs/dist/` contains `robots.txt`, `sitemap.xml`, `skills/<name>/SKILL.md` (x8), and `.well-known/agent-skills/index.json`
- [ ] `curl -s https://docs.scaffoldeth.io/robots.txt` → contains `Content-Signal:` line after deploy
- [ ] `curl -sI https://docs.scaffoldeth.io/sitemap.xml` → 200
- [ ] `curl -sI https://docs.scaffoldeth.io/.well-known/agent-skills/index.json` → 200 with `Content-Type: application/json`
- [ ] `curl -sI https://docs.scaffoldeth.io/ | grep -i ^link` → four resource pointers
- [ ] Validate index against schema: `curl -s .../index.json | jq` — 9 entries, each with `name`, `type: "skill-md"`, `description`, absolute `url`, `digest` starting `sha256:`
- [ ] Independent digest check: `shasum -a 256 <(curl -s https://docs.scaffoldeth.io/SKILL.md)` should match `ethereum-app-builder` entry's digest
- [ ] Re-scan at https://isitagentready.com/docs.scaffoldeth.io — expect 6/12

## Explicitly deferred: Markdown content negotiation

The `isitagentready` scorecard has a **Content: Markdown for Agents** check that expects a request with `Accept: text/markdown` to return the page body as markdown with `Content-Type: text/markdown`. This PR **does not** implement it, and we think that's the right call for now:

**Why it's not critical in practice.** SE-2 docs already expose the full corpus to agents via `/llms.txt` (index) and `/llms-full.txt` (every page concatenated as plain markdown). Those URLs are advertised on every response via `Link: </llms.txt>; rel="alternate"; type="text/plain"`. Any AI agent that respects the llms.txt convention can already fetch and ingest all docs content without touching HTML — the user need the check is meant to measure is already satisfied.

**Why the scorecard still fails.** The check is strict about the mechanism: it POSTs `/` with `Accept: text/markdown` and only passes on an exact `Content-Type: text/markdown` response. Cloudflare-hosted sites pass this automatically at the CDN edge; Vocs has no native support ([no issues or code referencing it](https://github.com/wevm/vocs/issues?q=markdown+negotiation) in upstream).

**How to close it later if needed.** A short follow-up PR with ~60 LOC gets it done:

1. Pre-build script (`scripts/gen-markdown-mirrors.ts`, ~30 LOC) that walks `docs/pages/**/*.{md,mdx}` and emits a twin at `docs/public/<route>.md` — copying `.md` verbatim and stripping leading `import`/`export` lines from `.mdx`.
2. One Vercel rewrite in `vercel.json` matching `Accept: text/markdown` via `has`, destination `$1.md`.
3. One header rule pinning `Content-Type: text/markdown` for `.md` paths.

Pure declarative — no Edge Middleware, no JS runtime cost, same build-time pattern as `gen-sitemap.ts` in this PR. Happy to ship it as a follow-up if the SE-2 team wants a clean `6/12 → 7/12` bump, but landing this PR first lets the existing wins deploy and be verified in isolation.

## Also out of scope for this PR

- `.well-known/mcp.json`, `.well-known/api-catalog`, WebMCP manifests — follow-up
- Cloudflare Web Bot Auth — structurally unreachable on Vercel without moving DNS
- OAuth discovery endpoints — not applicable to a static docs site

</details>

