### PR TITLE
Fix plausible tracking

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vocs";
+import { createElement } from "react";
 import { fetchSkills } from "./scripts/fetch-skills";
 import { generateAgentSkillsIndex } from "./scripts/gen-agent-skills-index";
 import { generateSitemap } from "./scripts/gen-sitemap";
@@ -22,6 +23,13 @@ export default defineConfig({
   logoUrl: "/img/logo.svg",
   iconUrl: "/img/favicon.png",
   baseUrl,
+  head: () =>
+    createElement("script", {
+      async: true,
+      defer: true,
+      "data-domain": "docs.scaffoldeth.io",
+      src: "https://plausible.io/js/plausible.js",
+    }),
   ogImageUrl: {
     "/": "https://vocs.dev/api/og?logo=%logo&title=%title&description=%description",
   },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vocs";
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 import { fetchSkills } from "./scripts/fetch-skills";
 import { generateAgentSkillsIndex } from "./scripts/gen-agent-skills-index";
 import { generateSitemap } from "./scripts/gen-sitemap";
@@ -24,12 +24,20 @@ export default defineConfig({
   iconUrl: "/img/favicon.png",
   baseUrl,
   head: () =>
-    createElement("script", {
-      async: true,
-      defer: true,
-      "data-domain": "docs.scaffoldeth.io",
-      src: "https://plausible.io/js/plausible.js",
-    }),
+    createElement(
+      Fragment,
+      null,
+      createElement("script", {
+        defer: true,
+        src: "https://plausible.io/js/pa-d22-c9SXWUaRHTRe7b4Uu.js",
+      }),
+      createElement("script", {
+        dangerouslySetInnerHTML: {
+          __html:
+            "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+        },
+      }),
+    ),
   ogImageUrl: {
     "/": "https://vocs.dev/api/og?logo=%logo&title=%title&description=%description",
   },


### PR DESCRIPTION
With the Vocs migration I think we missed the plausible analytics integration, adding it back using the Script approach from [plausible installation guide](https://plausible.io/docs.scaffoldeth.io/installation?type=manual&flow=review) 