### PR TITLE
docs: deprecate create-eth extensions in favor of Skills

### DIFF
--- a/docs/pages/extensions/createExtensions.md
+++ b/docs/pages/extensions/createExtensions.md
@@ -5,6 +5,10 @@ description: Build custom extensions for Scaffold-ETH 2.
 
 # Creating Your Own Extension
 
+:::warning[Deprecated]
+Extensions are deprecated and no longer actively maintained. To add features to your project, use [Skills](/build-with-ai) instead — they're more flexible and work anytime during development, not just at project creation.
+:::
+
 This section will help you develop custom extensions for Scaffold-ETH 2, from simple additions to more complex modifications.
 
 > Video Guide: For a visual walkthrough of the extension development process, check out our [YouTube tutorial](https://youtu.be/XQCv533XGZk?si=dlJH4zd4b99_6soW).

--- a/docs/pages/extensions/howToInstall.md
+++ b/docs/pages/extensions/howToInstall.md
@@ -5,6 +5,10 @@ description: Add extensions to your Scaffold-ETH 2 project.
 
 # How to Install Extensions
 
+:::warning[Deprecated]
+Extensions are deprecated and no longer actively maintained. To add features to your project, use [Skills](/build-with-ai) instead — they're more flexible and work anytime during development, not just at project creation.
+:::
+
 This guide explains what are extensions and how to use them in your Scaffold-ETH 2 project.
 
 ## What are Extensions?

--- a/docs/pages/extensions/index.mdx
+++ b/docs/pages/extensions/index.mdx
@@ -3,6 +3,10 @@ title: Extensions
 description: Modular add-ons for extending Scaffold-ETH 2 functionality.
 ---
 
+:::warning[Deprecated]
+Extensions are deprecated and no longer actively maintained. To add features to your project, use [Skills](/build-with-ai) instead — they're more flexible and work anytime during development, not just at project creation.
+:::
+
 ## What are Extensions?
 
 Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.

--- a/docs/pages/quick-start/installation.mdx
+++ b/docs/pages/quick-start/installation.mdx
@@ -37,10 +37,12 @@ If you choose Foundry as solidity framework in the CLI, you'll also need Foundry
 Checkout: [getfoundry.sh](https://getfoundry.sh/)
 :::
 
-If you want to use extensions, you can add the -e flag followed by the extension name:
+:::warning[Extensions are deprecated]
+Extensions are deprecated and no longer actively maintained. To add features to your project, use [Skills](/build-with-ai) instead — they work anytime during development, not just at project creation. The `-e` flag still works for existing extensions; see the [Extensions section](/extensions) for the legacy docs.
+:::
+
+To install an existing extension at creation time, add the `-e` flag followed by the extension name:
 
 ```bash [Terminal]
 npx create-eth@latest -e extension-name
 ```
-
-For more information about available extensions and how to use them, check out the [Extensions section](/extensions)

--- a/scripts/fetch-skills.ts
+++ b/scripts/fetch-skills.ts
@@ -83,9 +83,9 @@ The orchestrator skill is hosted at [\`docs.scaffoldeth.io/SKILL.md\`](https://d
 
 ## Skills vs Extensions
 
-[\`Extensions\`](/extensions) and skills solve different problems. Extensions run at project creation time (\`npx create-eth@latest\`) and add boilerplate files to your project. Skills work anytime during development. Your AI agent reads the skill instructions and adapts the implementation to your existing code, instead of dumping a fixed template.
+[\`Extensions\`](/extensions) are deprecated in favor of skills. Extensions ran at project creation time (\`npx create-eth@latest\`) and added a fixed set of boilerplate files to your project. Skills work anytime during development: your AI agent reads the skill instructions and adapts the implementation to your existing code, instead of dumping a fixed template.
 
-The plan is to eventually migrate all extensions to skills. Skills are more flexible since the agent can adapt to your existing codebase, and they don't require changes to the CLI scaffolding pipeline.
+Skills are the recommended replacement — they're more flexible since the agent can adapt to your existing codebase, and they don't require changes to the CLI scaffolding pipeline.
 
 ## Creating your own Skills
 


### PR DESCRIPTION
Marks create-eth extensions as deprecated and points users to Skills (Build with AI) as the replacement. Extension pages are kept (existing extensions still install) but carry a deprecation banner.

## Changes
- Add `Deprecated` banner to the three extension pages (`index`, `howToInstall`, `createExtensions`)
- Add deprecation note to the `-e` flag section in `quick-start/installation` (flag still works for existing extensions)
- Reframe the "Skills vs Extensions" section in `scripts/fetch-skills.ts` (source for the generated `build-with-ai/skills` page) — extensions are deprecated, Skills are the recommended path
- All "use Skills" CTAs link to the `/build-with-ai` overview

## Notes
- Pages/sidebar/URLs kept intact — no 404s for `/extensions/*`
- `docs/pages/build-with-ai/skills.md` is generated from `fetch-skills.ts`, so only the generator is committed

<details><summary>Warning example</summary>
<p>

<img width="1082" height="442" alt="image" src="https://github.com/user-attachments/assets/3a83e56e-4a8d-456d-95fb-6c8e88845a0b" />


</p>
</details> 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
