### PR TITLE
Fix llms.txt title generation and add AI-surface validation

### DIFF
--- a/docs/pages/recipes/ReadUintFromContract.mdx
+++ b/docs/pages/recipes/ReadUintFromContract.mdx
@@ -3,7 +3,7 @@ title: Read a uint from a contract
 description: Learn how to read from contract functions which accepts arguments / no arguments and display them on UI.
 ---
 
-# Read a `uint` from a contract
+# Read a uint from a contract
 
 This recipe demonstrates how to read data from contract functions and display it on the UI. We'll showcase an example that accepts some arguments (parameters), and another with no arguments at all.
 

--- a/docs/pages/recipes/WagmiContractWriteWithFeedback.mdx
+++ b/docs/pages/recipes/WagmiContractWriteWithFeedback.mdx
@@ -3,7 +3,7 @@ title: Wagmi useWriteContract with transaction status
 description: Show feedback on transaction status to user by `useWriteContract` along with `useTransactor`
 ---
 
-# Wagmi `useWriteContract` with transaction status
+# Wagmi useWriteContract with transaction status
 
 This recipe demonstrates how to create a button for contract interaction using the "useTransactor" and "useWriteContract" hooks from the "wagmi" library. The interaction includes the capability to provide feedback on the transaction status when using wagmi `useWriteContract`.
 

--- a/docs/pages/recipes/WriteToContractWriteAsyncButton.mdx
+++ b/docs/pages/recipes/WriteToContractWriteAsyncButton.mdx
@@ -3,7 +3,7 @@ title: Write to contract with writeContractAsync button
 description: Learn how to create a button that executes the writeContractAsync function to interact with a smart contract.
 ---
 
-# Write to a Contract with `writeContractAsync` button
+# Write to a Contract with writeContractAsync button
 
 This recipe shows how to implement a button that allows users to interact with a smart contract by executing the `writeContractAsync` function returned by [useScaffoldWriteContract](/hooks/useScaffoldWriteContract). By following this guide, you can create a user interface for writing data to a contract.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vocs dev",
     "build": "vocs build",
     "preview": "vocs preview",
+    "check:ai-surface": "node scripts/check-ai-surface.js",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/scripts/check-ai-surface.js
+++ b/scripts/check-ai-surface.js
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DIST_DIR = "docs/dist";
+const LLMS_FILE = path.join(DIST_DIR, "llms.txt");
+const FULL_LLMS_FILE = path.join(DIST_DIR, "llms-full.txt");
+const REQUIRED_PUBLIC_FILES = ["robots.txt", "sitemap.xml", "SKILL.md"];
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function assertFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    fail(`Missing ${filePath}. Run pnpm build before pnpm check:ai-surface.`);
+    return false;
+  }
+  return true;
+}
+
+function read(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function validateLlmsIndex() {
+  if (!assertFile(LLMS_FILE)) return;
+
+  const source = read(LLMS_FILE);
+  const entries = source.split(/\r?\n/).filter((line) => line.startsWith("- ["));
+
+  if (entries.length === 0) {
+    fail("llms.txt does not contain any Markdown link entries.");
+    return;
+  }
+
+  const badEntries = entries.filter((line) => {
+    const match = line.match(/^- \[([^\]]*)\]\(([^)]*)\)/);
+    if (!match) return true;
+
+    const title = match[1].trim();
+    const href = match[2].trim();
+    return (
+      title.length < 4 ||
+      title.endsWith(" ") ||
+      /^(Read a|Wagmi|Write to a Contract with)$/.test(title) ||
+      !href.startsWith("/")
+    );
+  });
+
+  if (badEntries.length > 0) {
+    fail(`llms.txt contains malformed entries:\n${badEntries.join("\n")}`);
+  }
+}
+
+function validateFullCorpus() {
+  if (!assertFile(FULL_LLMS_FILE)) return;
+  const source = read(FULL_LLMS_FILE);
+  if (!source.includes("Scaffold-ETH 2 | Docs")) {
+    fail("llms-full.txt is missing the docs title.");
+  }
+}
+
+function validatePublicFiles() {
+  for (const file of REQUIRED_PUBLIC_FILES) {
+    assertFile(path.join(DIST_DIR, file));
+  }
+}
+
+validateLlmsIndex();
+validateFullCorpus();
+validatePublicFiles();
+
+if (process.exitCode) {
+  process.exit();
+}
+
+console.log("✅ AI surface checks passed");


### PR DESCRIPTION
## What changed

- Removes inline code from three recipe H1 headings so Vocs generates complete `llms.txt` titles.
- Adds `pnpm check:ai-surface` to validate generated AI-facing files after `pnpm build`.
- Checks generated `llms.txt`, `llms-full.txt`, `robots.txt`, `sitemap.xml`, and `SKILL.md` exist and catch malformed AI index entries.

## Why

The public `llms.txt` index was emitting truncated titles for headings with inline code, which makes AI retrieval and page selection less reliable.

Fixes #164

## Merge order

Independent. This PR can be merged in any order relative to #165 and #166.

## Validation

- `pnpm build`
- `pnpm check:ai-surface`
