### PR TITLE
Add agent discovery manifest

### DIFF
--- a/scripts/gen-agent-manifest.ts
+++ b/scripts/gen-agent-manifest.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const OUTPUT = "docs/public/.well-known/agent.json";
+const PRODUCTION_URL = "https://docs.scaffoldeth.io";
+
+function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_URL;
+}
+
+let generated = false;
+
+export function generateAgentManifest(): void {
+  if (generated) return;
+  generated = true;
+
+  const baseUrl = resolveBaseUrl();
+  const manifest = {
+    name: "Scaffold-ETH 2 Docs",
+    description: "AI agent entrypoints for building full-stack Ethereum dapps with Scaffold-ETH 2.",
+    homepage_url: baseUrl,
+    repository_url: "https://github.com/scaffold-eth/se-2-docs",
+    project_repository_url: "https://github.com/scaffold-eth/scaffold-eth-2",
+    entrypoints: {
+      orchestrator_skill: `${baseUrl}/SKILL.md`,
+      docs_index: `${baseUrl}/llms.txt`,
+      full_docs_corpus: `${baseUrl}/llms-full.txt`,
+      skill_index: `${baseUrl}/.well-known/agent-skills/index.json`,
+      build_with_ai: `${baseUrl}/build-with-ai`,
+      agents_md_guide: `${baseUrl}/build-with-ai/agents-md`,
+      skills_guide: `${baseUrl}/build-with-ai/skills`,
+    },
+    defaults: {
+      scaffold_command: "npx -y create-eth@latest -s foundry <project-name>",
+      default_contract_framework: "foundry",
+      package_manager: "yarn",
+      local_dev_commands: ["yarn chain", "yarn deploy", "yarn start"],
+    },
+    supported_workflows: [
+      "scaffold a new Scaffold-ETH 2 dapp",
+      "build Solidity contracts with a Next.js frontend",
+      "use AGENTS.md for project-specific coding-agent context",
+      "select project-local skills from .agents/skills",
+      "add common web3 integrations using Scaffold-ETH 2 patterns",
+    ],
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(manifest, null, 2) + "\n");
+
+  console.log(`✅ Generated agent.json (base: ${baseUrl})`);
+}

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vocs";
 import { fetchSkills } from "./scripts/fetch-skills";
+import { generateAgentManifest } from "./scripts/gen-agent-manifest";
 import { generateAgentSkillsIndex } from "./scripts/gen-agent-skills-index";
 import { generateSitemap } from "./scripts/gen-sitemap";
 
 const skills = await fetchSkills();
 generateSitemap();
+generateAgentManifest();
 generateAgentSkillsIndex();
 
 const skillSidebarItems = skills.map((s) => ({


### PR DESCRIPTION
## What changed

- Adds a build-time generator for `/.well-known/agent.json`.
- Links core AI entrypoints: `SKILL.md`, `llms.txt`, `llms-full.txt`, `/.well-known/agent-skills/index.json`, Build with AI docs, AGENTS.md docs, and Skills docs.
- Includes basic Scaffold-ETH defaults and supported AI-agent workflows.

## Why

The docs already have strong AI resources, but agents need one predictable manifest that ties them together.

Fixes #165

## Merge order

Independent. This PR can be merged in any order relative to #164 and #166.

## Validation

- `pnpm build`
- Parsed `docs/dist/.well-known/agent.json` with Node and verified key entrypoints.
