### PR TITLE
Use page-level dates in sitemap

### DIFF
--- a/scripts/gen-sitemap.ts
+++ b/scripts/gen-sitemap.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const PAGES_DIR = "docs/pages";
 const OUTPUT = "docs/public/sitemap.xml";
@@ -16,8 +17,15 @@ function resolveBaseUrl(): string {
   return PRODUCTION_URL;
 }
 
-function collectRoutes(dir: string, basePath = ""): string[] {
-  const routes: string[] = [];
+type Route = {
+  path: string;
+  sourceFile: string;
+};
+
+let gitLastmodCache: Map<string, string> | null = null;
+
+function collectRoutes(dir: string, basePath = ""): Route[] {
+  const routes: Route[] = [];
 
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const { name } = entry;
@@ -34,10 +42,48 @@ function collectRoutes(dir: string, basePath = ""): string[] {
 
     const bare = name.replace(/\.(md|mdx)$/, "");
     const route = bare === "index" ? basePath || "/" : `${basePath}/${bare}`;
-    routes.push(route);
+    routes.push({ path: route, sourceFile: full });
   }
 
   return routes;
+}
+
+function getGitLastmods(): Map<string, string> {
+  if (gitLastmodCache) return gitLastmodCache;
+
+  gitLastmodCache = new Map();
+
+  try {
+    const output = execFileSync("git", ["log", "--format=@@%cI", "--name-only", "--", PAGES_DIR], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+    let currentDate = "";
+
+    for (const line of output.split(/\r?\n/)) {
+      if (line.startsWith("@@")) {
+        currentDate = line.slice(2, 12);
+        continue;
+      }
+
+      if (!currentDate || !line.startsWith(`${PAGES_DIR}/`)) continue;
+      if (!gitLastmodCache.has(line)) {
+        gitLastmodCache.set(line, currentDate);
+      }
+    }
+  } catch {
+    // Vercel builds normally include Git metadata; local archives may not.
+  }
+
+  return gitLastmodCache;
+}
+
+function getLastmod(sourceFile: string): string {
+  const gitDate = getGitLastmods().get(sourceFile);
+  if (gitDate) return gitDate;
+
+  return fs.statSync(sourceFile).mtime.toISOString().slice(0, 10);
 }
 
 function escapeXml(value: string): string {
@@ -49,18 +95,16 @@ function escapeXml(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-function toXml(routes: string[], baseUrl: string): string {
-  const lastmod = new Date().toISOString().slice(0, 10);
-
+function toXml(routes: Route[], baseUrl: string): string {
   const urls = [...routes]
-    .sort()
+    .sort((a, b) => a.path.localeCompare(b.path))
     .map((route) => {
-      const loc = escapeXml(route === "/" ? baseUrl : `${baseUrl}${route}`);
-      const priority = route === "/" ? "1.0" : "0.8";
+      const loc = escapeXml(route.path === "/" ? baseUrl : `${baseUrl}${route.path}`);
+      const priority = route.path === "/" ? "1.0" : "0.8";
       return [
         "  <url>",
         `    <loc>${loc}</loc>`,
-        `    <lastmod>${lastmod}</lastmod>`,
+        `    <lastmod>${getLastmod(route.sourceFile)}</lastmod>`,
         `    <changefreq>weekly</changefreq>`,
         `    <priority>${priority}</priority>`,
         "  </url>",


### PR DESCRIPTION
## What changed

- Tracks each sitemap route's source page file.
- Uses the page file's latest Git commit date for `lastmod`.
- Falls back to filesystem mtime when Git metadata is unavailable.
- Batches Git history lookup so build time stays close to the existing baseline.

## Why

A single build-wide `lastmod` date is too coarse for crawlers and AI/RAG ingestion jobs. Page-level freshness helps downstream consumers prioritize only changed docs.

Fixes #166

## Merge order

Independent. This PR can be merged in any order relative to #164 and #165.

## Validation

- `pnpm build`
- Checked generated `docs/dist/sitemap.xml`: 46 URLs, 5 unique `lastmod` values in this checkout.
