### PR TITLE
Update repo name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ To run the Documentation site locally, first ensure you have [Node](https://node
 Clone the repository, install all dependencies, and then start Vocs.
 
 ```bash
-git clone https://github.com/scaffold-eth/se2-docs.git
-cd se2-docs
+git clone https://github.com/scaffold-eth/docs.scaffoldeth.io.git
+cd docs.scaffoldeth.io
 pnpm install
 pnpm dev
 ```

--- a/docs/footer.tsx
+++ b/docs/footer.tsx
@@ -72,7 +72,7 @@ export default function Footer() {
             Scaffold-Eth 2 GitHub ↗
           </a>
           <a
-            href="https://github.com/scaffold-eth/se-2-docs"
+            href="https://github.com/scaffold-eth/docs.scaffoldeth.io"
             target="_blank"
             rel="noreferrer"
             style={linkStyle}

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -241,7 +241,7 @@ export default defineConfig({
   ],
   editLink: {
     pattern:
-      "https://github.com/scaffold-eth//se-2-docs/edit/main/docs/pages/:path",
+      "https://github.com/scaffold-eth/docs.scaffoldeth.io/edit/main/docs/pages/:path",
     text: "Suggest changes to this page",
   },
 });


### PR DESCRIPTION
Just renamed the repo from `se-2-docs` to `docs.scaffoldeth.io`

I know Github does the redirect, but I think it's good to update it here.

(not sure if we have a link to this github repo somewhere else)