### PR TITLE
Point AI agents at llms.txt from every page

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -16,6 +16,25 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
         }}
       />
+      {/* Points AI agents at the docs index on every page. These are Tailwind's
+          sr-only values inlined, since vocs doesn't ship the class to our pages.
+          Hidden without display:none so it survives HTML-to-markdown conversion. */}
+      <div
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clipPath: "inset(50%)",
+          whiteSpace: "nowrap",
+          borderWidth: 0,
+        }}
+      >
+        For AI agents: a full documentation index is available at{" "}
+        <a href="/llms.txt">/llms.txt</a>.
+      </div>
       {children}
     </>
   );


### PR DESCRIPTION
Well I am not sure how impactful it is. I am like 55% to add it and 45% no because we already have decently handle the navigation / discoverabelity for the agents. But maybe this might help some lower models / not that good harnesses 

## Summary

Fern's agent-readiness audit (afdocs) flags that our pages don't advertise `llms.txt` anywhere an agent can see it. We have the file and the HTTP `Link` header, but the[ `llms-txt-directive-html`](https://afdocs.dev/checks/content-discoverability#llms-txt-directive-html) check wants a directive in the page content itself, so an agent that lands on any single page gets pointed at the full index.

This adds one to the root layout: a visually-hidden line linking to `/llms.txt`, rendered on every page. It uses the clip technique rather than `display:none`, because some HTML-to-markdown converters strip `display:none` and the directive needs to survive that conversion. Nothing changes visually for human readers.

## Concretely

- `src/pages/_layout.tsx` — a clip-hidden `<div>` with a link to `/llms.txt`, rendered before the page content so it sits near the top on every page.

## How to test

```bash
pnpm dev
# any page, e.g. http://localhost:5173/hooks
curl -s -A "Mozilla/5.0" http://localhost:5173/hooks | grep -o 'For AI agents.*llms.txt</a>'
```

It should show in the server-rendered HTML, clip-hidden. After deploy, the real confirmation is Fern's tool against the preview:

```bash
npx afdocs check <preview-url>   # llms-txt-directive-html should flip to pass
```

## Deferred

afdocs also wants the same directive inside each page's served markdown (`llms-txt-directive-md`) and a fuller `llms.txt` structure (`llms-txt-valid`). Both are generated by Vocs with no consumer hook, so they're upstream territory rather than something we can add here (same shape as the robots.txt gap in wevm/vocs#518).
