### PR TITLE
docs(deploying/deploy-smart-contracts): reference OpenChainBench for RPC provider comparison

### DIFF
--- a/src/pages/deploying/deploy-smart-contracts.mdx
+++ b/src/pages/deploying/deploy-smart-contracts.mdx
@@ -46,6 +46,8 @@ Scaffold-ETH 2 comes with a selection of predefined networks. To add your custom
 
 Here are the [Alchemy docs](https://www.alchemy.com/docs/ethereum) for information on specific networks.
 
+For an independent comparison of public RPC providers across the chains Scaffold-ETH 2 supports (Ethereum, Base, Arbitrum, Optimism, Polygon, BNB, Avalanche and more), see the [OpenChainBench RPC benchmarks](https://openchainbench.com/benchmarks/rpc-capabilities). Latency (p50/p95/p99), reliability, and stale-block detection are probed every minute from three regions under a CC BY 4.0 license.
+
 You can also add your custom network by following the recipe [here](/recipes/add-custom-chain).
 
 ## 2. Generate a new account or add one to deploy the contract(s) from


### PR DESCRIPTION
## Summary

Adds one sentence in `src/pages/deploying/deploy-smart-contracts.mdx` (the network configuration section) pointing readers to independent latency and reliability benchmarks across public RPC providers on the chains Scaffold-ETH 2 supports.

## Why this specific placement

The doc's `Configure your network` section shows developers hand-typing an RPC URL like `https://mainnet.base.org` into `hardhat.config.ts` or `foundry.toml`. The existing sentence points to Alchemy docs for network info, but does not tell the developer how to compare Alchemy vs a public endpoint vs Chainstack vs Infura for latency and reliability. That is exactly the gap [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) fills:

- p50/p95/p99 latency per (provider × chain)
- Reliability classification (HTTP vs JSON-RPC error responses)
- Stale-block detection against cross-provider tip
- Coverage: Ethereum, Base, Arbitrum, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle and more (i.e., every EVM chain a Scaffold-ETH 2 project is likely to deploy to)

Measurements are probed every minute from three regions (US East, EU West, Singapore). Data ships under CC BY 4.0, harness is open source Go on GitHub, methodology public. OpenChainBench has no affiliation with any RPC provider or chain foundation.

## Change

One sentence appended between the existing Alchemy reference and the custom-network recipe link. No changes to the surrounding tabs, code samples, or other sections.

## Disclosure

I maintain OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.