### PR TITLE
Frame the components index around what developers ask for

### DIFF
--- a/src/pages/components/index.mdx
+++ b/src/pages/components/index.mdx
@@ -1,15 +1,13 @@
 ---
 title: Components
-description: Drop-in React components for connecting a wallet, displaying addresses and balances, and taking ETH input, ready to use in any Scaffold-ETH 2 project.
+description: Drop-in React components for connecting a wallet, displaying addresses and balances, and taking ETH input.
 ---
 
 # ⚙ Components
 
-Scaffold-ETH 2 ships with reusable React components for the things almost every dapp needs: connecting a wallet, displaying an address with ENS resolution, showing an ETH balance, and taking addresses or ETH amounts as input. Import them from `~~/components/scaffold-eth` and drop them into your own pages.
+Scaffold-ETH 2 ships with reusable, drop-in React components for the things almost every dapp needs: connecting a wallet, displaying an address with ENS resolution, showing an ETH balance, and taking addresses or ETH amounts as input. For reading from and writing to your contracts, it also ships [custom hooks](/hooks) that wrap wagmi.
 
-The connect button is built on RainbowKit. For reading from and writing to your contracts, Scaffold-ETH 2 also ships [custom hooks](/hooks) that wrap wagmi.
-
-Most of these components are powered by [**Scaffold-UI**](https://scaffold-ui-docs.vercel.app/), a standalone library that provides the underlying components and UI hooks. The examples below show how they work within a Scaffold-ETH 2 project. For more details on customization, theming, and advanced usage, check the [Scaffold-UI documentation](https://scaffold-ui-docs.vercel.app/).
+Most of these components are powered by [**Scaffold-UI**](https://scaffold-ui-docs.vercel.app/), a standalone library that comes pre-installed in every Scaffold-ETH 2 project; import them from `@scaffold-ui/components`. The app-specific ones live in your project at `~~/components/scaffold-eth`. The main one is the wallet connect button, built on [RainbowKit](https://rainbowkit.com) and extended with Scaffold-ETH 2's network and balance UI. For customization, theming, and advanced usage, check the [Scaffold-UI documentation](https://scaffold-ui-docs.vercel.app/).
 
 ## Available Components
 

--- a/src/pages/components/index.mdx
+++ b/src/pages/components/index.mdx
@@ -1,11 +1,13 @@
 ---
 title: Components
-description: Pre-built React components for common web3 use cases.
+description: Drop-in React components for connecting a wallet, displaying addresses and balances, and taking ETH input, ready to use in any Scaffold-ETH 2 project.
 ---
 
 # ⚙ Components
 
-Scaffold-ETH 2 provides a set of pre-built components for common web3 use cases. You can make use of them to accelerate and simplify your dapp development.
+Scaffold-ETH 2 ships with reusable React components for the things almost every dapp needs: connecting a wallet, displaying an address with ENS resolution, showing an ETH balance, and taking addresses or ETH amounts as input. Import them from `~~/components/scaffold-eth` and drop them into your own pages.
+
+The connect button is built on RainbowKit. For reading from and writing to your contracts, Scaffold-ETH 2 also ships [custom hooks](/hooks) that wrap wagmi.
 
 Most of these components are powered by [**Scaffold-UI**](https://scaffold-ui-docs.vercel.app/), a standalone library that provides the underlying components and UI hooks. The examples below show how they work within a Scaffold-ETH 2 project. For more details on customization, theming, and advanced usage, check the [Scaffold-UI documentation](https://scaffold-ui-docs.vercel.app/).
 


### PR DESCRIPTION
## Summary

The components index opened by describing itself, "Scaffold-ETH 2 provides a set of pre-built components for common web3 use cases", rather than saying what the components actually do. Nothing anywhere in `/components` mentioned wallet connection, wagmi, or dropping a component into an existing project.

This rewrites the intro and the frontmatter description to name the jobs: wallet connection, address display with ENS, ETH balance, and address and ETH inputs. It adds a pointer across to the hooks, since contract reads and writes are the other half of the same question.

Content only. No components, examples or list entries changed.

## Why

We have been tracking how Claude answers a fixed set of Ethereum developer questions, as part of the BuidlGuidl AI-visibility work. One of them is:

> *"Are there reusable web3 React components (connect wallet, address, balance) and Wagmi hooks I can drop in?"*

Scaffold-ETH 2 does not appear in the answer at all. It goes to Wagmi, RainbowKit and MetaMask, cited from `wagmi.sh` and `rainbowkit.com`.

That is not a gap in the docs. `Address`, `Balance`, `AddressInput`, `EtherInput` and `RainbowKitCustomConnectButton` are all documented here, and `/hooks` covers the wagmi side. The answer exists; the page just does not phrase itself the way the question is phrased. For context, Scaffold-ETH 2 is already the primary recommendation in 9 of the 10 starter-kit questions we track, so this is one of the few adjacent questions where it is absent despite shipping the thing being asked for.

Worth being straight about the limits: this is one model, one run, and one phrasing. I would not promise it changes the answer. It seemed worth fixing regardless, because the current intro does not describe the section well for a human reader either.

## Concretely

- `src/pages/components/index.mdx`: intro rewritten, frontmatter `description` rewritten.
- The description change also lands in `llms.txt`, since vocs v2 generates it from frontmatter.

One deliberate omission: the intro does not say the components are built on wagmi. The hooks page says the hooks are wagmi wrappers, but nothing in the repo says that about the components, so the two are kept separate rather than blurred.

## How to test

```bash
pnpm dev
# http://localhost:5173/components
curl -s -A "Mozilla/5.0" http://localhost:5173/components | grep -o 'connecting a wallet'
curl -s http://localhost:5173/llms.txt | grep -i 'components/'
```

Check the `/hooks` link resolves, and that the component list below the intro is unchanged.
