### PR TITLE
Add the missing h1 on /extensions

### DIFF
--- a/src/pages/extensions/index.mdx
+++ b/src/pages/extensions/index.mdx
@@ -3,6 +3,8 @@ title: Extensions
 description: Modular add-ons for extending Scaffold-ETH 2 functionality.
 ---
 
+# 🔌 Extensions
+
 ## What are Extensions?
 
 Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.


### PR DESCRIPTION
## Summary

`/extensions` opens straight into `## What are Extensions?` with no page heading above it.
This adds one, matching what every other section overview does.

## Why

Found while checking headings across the docs: 45 of the 46 pages have exactly one h1,
and this is the one that does not. Every other section overview leads with the same shape,
an h1 carrying the section's sidebar emoji:

- `/components` → "⚙ Components"
- `/hooks` → "🛠 Interacting with Your Smart Contracts"
- `/external-contracts` → "📡 Interacting with External Contracts"
- `/build-with-ai` → "🤖 Build with AI"
- `/contributing` → "🙏 Contributing to Scaffold-ETH 2"

Beyond consistency, the h1 is what browsers, search results and AI assistants read as the
page's heading. On this page there is nothing for them to read, so the page presents itself
with a question instead of a name.

## Concretely

- `src/pages/extensions/index.mdx`: one heading added above the existing content.
- No copy changes. The existing headings and their anchors, `#what-are-extensions` and
  `#get-started`, are untouched, so any existing links still land in the same place.

## How to test

```bash
pnpm dev
# http://localhost:5173/extensions
```

The page opens with "🔌 Extensions" and reads as before underneath. Every other page is
unaffected.
