### PR TITLE
Use each skill's own heading as its page title

### DIFF
--- a/scripts/fetch-skills.ts
+++ b/scripts/fetch-skills.ts
@@ -14,6 +14,13 @@ export type Skill = {
   shortDesc: string;
 };
 
+// Title the page from the skill's own heading, minus the tail every skill repeats.
+function skillTitle(name: string, body: string): string {
+  const heading = body.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  if (!heading) return name;
+  return heading.replace(/(?:\s+Integration)?\s+for Scaffold-ETH 2$/i, "").trim() || name;
+}
+
 async function getSkillNames(): Promise<string[]> {
   const res = await fetch(GITHUB_API);
   if (!res.ok) return [];
@@ -38,10 +45,12 @@ async function fetchAndWriteSkill(name: string): Promise<Skill | null> {
     ? descMatch[1].split(". Use when")[0]
     : `${name} skill for Scaffold-ETH 2`;
 
+  const title = skillTitle(name, body);
+
   // Vocs frontmatter for page meta, original frontmatter as visible code block
   fs.writeFileSync(
     path.join(SKILLS_DIR, `${name}.md`),
-    `---\ntitle: "${name}"\ndescription: "${shortDesc}"\n---\n\n\`\`\`yaml\n---\n${originalFrontmatter}\n---\n\`\`\`\n\n${body}`,
+    `---\ntitle: "${title}"\ndescription: "${shortDesc}"\n---\n\n\`\`\`yaml\n---\n${originalFrontmatter}\n---\n\`\`\`\n\n${body}`,
   );
 
   // Raw, untouched SKILL.md for agent discovery index (/.well-known/agent-skills)
@@ -49,7 +58,7 @@ async function fetchAndWriteSkill(name: string): Promise<Skill | null> {
   fs.mkdirSync(rawDir, { recursive: true });
   fs.writeFileSync(path.join(rawDir, "SKILL.md"), raw);
 
-  return { name, title: name, shortDesc };
+  return { name, title, shortDesc };
 }
 
 function writeSkillsOverview(skills: Skill[]) {
@@ -118,7 +127,11 @@ function readExistingSkills(): Skill[] | null {
 
   return files.map((f) => {
     const name = f.replace(".md", "");
-    return { name, title: name, shortDesc: "" };
+    // Read the title back from the fetched page so cached runs match cold ones.
+    const page = fs.readFileSync(path.join(SKILLS_DIR, f), "utf8");
+    const frontmatter = page.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+    const title = frontmatter.match(/^title:\s*"(.*)"$/m)?.[1] || name;
+    return { name, title, shortDesc: "" };
   });
 }
 

--- a/scripts/fetch-skills.ts
+++ b/scripts/fetch-skills.ts
@@ -136,7 +136,6 @@ function readExistingSkills(): Skill[] | null {
 }
 
 export async function fetchSkills(): Promise<Skill[]> {
-  // Skip fetch if pages already exist (Vocs evaluates config multiple times)
   const existing = readExistingSkills();
   if (existing) return existing;
 


### PR DESCRIPTION
## Summary

Eight pages under `/build-with-ai` show up as lowercase folder names, in the sidebar and in
the browser tab. Each page already opens with a written heading, so this takes the title
from the heading.

| Page | Now | After |
| --- | --- | --- |
| `/build-with-ai/ponder` | ponder | Ponder |
| `/build-with-ai/siwe` | siwe | Sign-In with Ethereum (SIWE) |
| `/build-with-ai/x402` | x402 | x402 Payment Protocol |
| `/build-with-ai/erc-721` | erc-721 | ERC-721 NFT |
| `/build-with-ai/eip-5792` | eip-5792 | EIP-5792 |
| `/build-with-ai/subgraph` | subgraph | The Graph Subgraph |
| `/build-with-ai/drizzle-neon` | drizzle-neon | Drizzle ORM + Neon PostgreSQL |
| `/build-with-ai/openzeppelin` | openzeppelin | Develop Smart Contracts with OpenZeppelin |

## Why

The titles are not written anywhere in this repo. The skill pages are fetched from
`scaffold-eth-2` at build time by `scripts/fetch-skills.ts`, which had no title to use and
fell back to the folder name, so the fix belongs in the generator. Their hand-written
neighbours, "AGENTS.md" and "Skills", render correctly.

No visibility claim here. It stops the sidebar reading like a directory listing.

## Concretely

- `scripts/fetch-skills.ts`: title comes from the first `#` heading, minus the
  `[Integration] for Scaffold-ETH 2` tail. `titleTemplate` already appends the site name.
- Each page keeps its heading verbatim, so "Ponder Integration for Scaffold-ETH 2" still
  reads at the top. Only the label changes.
- The folder name stays the identifier: route, the raw mirror in `public/skills/`, and
  `name` in `/.well-known/agent-skills/index.json` are unchanged.
- `fetchSkills` reads the title back from the page it wrote on cached runs, since Vocs
  evaluates the config more than once per build.
- One file. The skill pages are generated and gitignored.

Derived rather than a hand-kept list, so new skills need no upkeep. It is blind, though: a
skill headed "Continuous Integration for Scaffold-ETH 2" would come out as "Continuous".

## How to test

```bash
pnpm generate
head -3 src/pages/build-with-ai/ponder.md                  # title: "Ponder"
grep '"name"' public/.well-known/agent-skills/index.json   # still ponder, siwe, x402, ...

pnpm dev
# http://localhost:5173/build-with-ai/ponder
```

Sidebar entries read as titles, the table on `/build-with-ai/skills` uses the same names,
`llms.txt` picks them up. Routes are unchanged.
