### PR TITLE
Stop the homepage title repeating the site name

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Scaffold-ETH 2
+title: Scaffold-ETH 2 Docs
 description: Open-source toolkit for building decentralized applications on Ethereum.
 ---
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -28,7 +28,9 @@ const baseUrl =
     : undefined;
 
 export default defineConfig({
-  title: "🏗 Scaffold-ETH 2 | Docs",
+  // Site name only. Vocs skips titleTemplate when a page title already contains it.
+  title: "Scaffold-ETH 2 Docs",
+  titleTemplate: "%s – 🏗 Scaffold-ETH 2 Docs",
   description: "Open-source toolkit for building dapps",
   logoUrl: "/img/logo.svg",
   iconUrl: "/img/favicon.png",


### PR DESCRIPTION
## Summary

The homepage renders as `Scaffold-ETH 2 – 🏗 Scaffold-ETH 2 | Docs`. This separates the site
name from its decoration so the name appears once.

| Page | Now | After |
| --- | --- | --- |
| `/` | Scaffold-ETH 2 – 🏗 Scaffold-ETH 2 \| Docs | Scaffold-ETH 2 Docs |
| `/components` | Components – 🏗 Scaffold-ETH 2 \| Docs | Components – 🏗 Scaffold-ETH 2 Docs |

## Why

Vocs composes a page title from `titleTemplate`, and skips the template when the page's own
title already contains the site name. `title` here carried the decoration as well as the
name, so the homepage's "Scaffold-ETH 2" did not match, the template applied, and the name
landed twice.

Follow-up to #181, same pass over how titles are produced.

## Concretely

- `vocs.config.ts`: `title` is the site name, `titleTemplate` carries the decoration.
- `src/pages/index.mdx`: the homepage title becomes "Scaffold-ETH 2 Docs", which is what
  makes Vocs skip the template. Inner pages change only in the separator.
- No emoji in either page title on purpose. `og:title`, `twitter:title` and the vocs.dev OG
  image all read the page title, and that renderer has no emoji font, so a 🏗 there comes out
  as a tofu box on every share card. The emoji stays in `titleTemplate`, which only reaches
  `<title>`.
- `og:site_name` and the `llms.txt` heading follow `title` and now read "Scaffold-ETH 2 Docs".
  Every other page's `og:title`, description and `llms.txt` entry is untouched.

## How to test

```bash
pnpm build && pnpm preview
curl -sA "Mozilla/5.0" http://localhost:4173/ | grep -o '<title>[^<]*</title>'
curl -sA "Mozilla/5.0" http://localhost:4173/components | grep -o '<title>[^<]*</title>'
curl -s http://localhost:4173/llms.txt | head -3
```

Homepage reads `Scaffold-ETH 2 Docs`, inner pages `<page> – 🏗 Scaffold-ETH 2 Docs`.
